### PR TITLE
fixed tests

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -49,7 +49,7 @@ const ROLES = {
 
 const cleanCollection = async () => {
   const o = muri(stringConnection)
-  const client = await MongoClient.connect(stringConnection)
+  const client = await MongoClient.connect(stringConnection, { useUnifiedTopology: true })
   const collection = client.db(o.db).collection(tableName);
   await collection.deleteMany()
   await client.close()
@@ -210,7 +210,7 @@ describe('CRUD', () => {
           title: 'My first post modified'
         }
 
-        crud.update(doc_created._id, doc_update, PERMISSION.save, {}, (err, result) => {
+        crud.update({ _id: doc_created._id }, doc_update, PERMISSION.save, {}, (err, result) => {
           if (err) done(new Error(err))
           expect(result.title).to.be.deep.equal('My first post modified')
           done()
@@ -231,7 +231,7 @@ describe('CRUD', () => {
       crud.create(doc, PERMISSION.save, {}, (err, doc_created) => {
         if (err) done(new Error(err))
 
-        crud.delete(doc_created._id, PERMISSION.delete, {}, (err, result) => {
+        crud.delete({ _id: doc_created._id }, PERMISSION.delete, {}, (err, result) => {
           expect(err).to.be.deep.equal(null)
           expect(result.title).to.be.deep.equal('My first post')
 
@@ -349,7 +349,7 @@ describe('CRUD', () => {
           title: 'My first post modified'
         }
 
-        crud.update(doc_created._id, doc_update, PERMISSION.save, {}, (err, result) => {
+        crud.update({ _id: doc_created._id }, doc_update, PERMISSION.save, {}, (err, result) => {
           if (err) done(new Error(err))
           expect(doc_created.createdAt).not.to.be.null
           expect(doc_created.updateAt).not.to.be.null

--- a/tests/upsertMany.js
+++ b/tests/upsertMany.js
@@ -32,7 +32,7 @@ describe('MANY', () => {
 
   before(async () => {
     const { db: dbName } = muri(stringConnection)
-    const client = await MongoClient.connect(stringConnection)
+    const client = await MongoClient.connect(stringConnection, { useUnifiedTopology: true })
     const collection = client.db(dbName).collection(tableName)
     await collection.insertMany([{ title: "Title 1", code: 1 }, { title: "Title 2", code: 2 }, { title: "Title 3", code: 3 }])
     await client.close()
@@ -40,7 +40,7 @@ describe('MANY', () => {
 
   after(async () => {
     const { db: dbName } = muri(stringConnection)
-    const client = await MongoClient.connect(stringConnection)
+    const client = await MongoClient.connect(stringConnection, { useUnifiedTopology: true })
     const collection = client.db(dbName).collection(tableName)
     await collection.deleteMany()
     await client.close()


### PR DESCRIPTION
Some tests failed because they received an objectId instead of an object in the query params for mongo operations.
It seems like tests were already broken in the latest published version.

This commit fixed these problems.